### PR TITLE
Packaging python-etcd

### DIFF
--- a/dependencies/Makefile
+++ b/dependencies/Makefile
@@ -1,0 +1,23 @@
+NAME = python-etcd
+VERSION = 0.4.3
+
+all: srpm
+
+clean:
+	rm -rf dist/
+	rm -rf $(NAME)-$(VERSION).tar.gz
+	rm -rf $(NAME)-$(VERSION)-1.src.rpm
+	rm -fr *.log
+
+dist:
+	git clone https://github.com/jplana/python-etcd $(NAME)-$(VERSION)
+	tar -zcvf python-etcd-0.4.3.tar.gz $(NAME)-$(VERSION)
+	rm -fr $(NAME)-$(VERSION)
+
+srpm: dist
+	fedpkg --dist epel7 srpm
+
+rpm:  srpm
+	mock -r epel-7-x86_64 rebuild $(NAME)-$(VERSION)-1.src.rpm --resultdir=.
+
+.PHONY: dist rpm srpm

--- a/dependencies/python-etcd.spec
+++ b/dependencies/python-etcd.spec
@@ -1,0 +1,41 @@
+%define name python-etcd
+%define version 0.4.3
+%define unmangled_version 0.4.3
+%define unmangled_version 0.4.3
+%define release 1
+
+Summary: A python client for etcd
+Name: %{name}
+Version: %{version}
+Release: %{release}
+Source0: %{name}-%{unmangled_version}.tar.gz
+License: MIT
+Group: Development/Libraries
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
+Prefix: %{_prefix}
+BuildArch: noarch
+Vendor: Jose Plana <jplana@gmail.com>
+Url: http://github.com/jplana/python-etcd
+
+BuildRequires: pytest
+BuildRequires: python2-devel
+
+%description
+python-etcd documentation
+A python client for Etcd https://github.com/coreos/etcd
+Official documentation: http://python-etcd.readthedocs.org/
+
+%prep
+%setup -n %{name}-%{unmangled_version} -n %{name}-%{unmangled_version}
+
+%build
+python setup.py build
+
+%install
+python setup.py install --single-version-externally-managed -O1 --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files -f INSTALLED_FILES
+%defattr(-,root,root)


### PR DESCRIPTION
Added Makefile and spec file to create python-etcd package
Now one can use "make rpm" to pull the latest source from github
and build the source rpm
and using the Makefile one can also build rpm using "make rpm"
which will use mock to build the rpm using srpm.

Signed-off-by: Timothy Asir J <tjeyasin@redhat.com>