### PR TITLE
Makefile: safer "make clean" operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ all: srpm
 
 clean:
 	rm -rf dist/
-	rm -rf $(NAME)-$(VERSION).tar.gz
-	rm -rf $(NAME)-$(VERSION)-1.el7.src.rpm
+	rm -f $(NAME)-$(VERSION).tar.gz
+	rm -f $(NAME)-$(VERSION)-1.el7.src.rpm
 
 dist:
 	python setup.py sdist \


### PR DESCRIPTION
`make clean` deletes single files. There's no need for the "-r" (recursive) flag, and it's dangerous to run rm recursively unless absolutely necessary.