### PR TITLE
Enhanced to look for node_ids parameter in job

### DIFF
--- a/etc/samples/tendrl_api_job.sample.json
+++ b/etc/samples/tendrl_api_job.sample.json
@@ -10,6 +10,7 @@
 	"cluster_id": "bc35fde8-528b-4908-8d52-50d8bf964dd4",
 	"sds_name": "gluster",
 	"sds_version": "3.2.0",
+	"node_ids": ["node_id1", ...],
 	"run": "tendrl.gluster_integration.flows.create_volume.CreateVolume",
 	"status": "new",
 	"parameters": {
@@ -24,7 +25,7 @@
 
 {
 	"cluster_id": "bc35fde8-528b-4908-8d52-50d8bf964dd4",
-	"node_id": "node_id", 
+	"node_ids": ["node_id1", ...],
 	"run": "tendrl.node_agent.gluster_integration.flows.import_cluster.ImportCluster",
 	"status": "new",
 	"parameters": {

--- a/tendrl/common/manager/manager.py
+++ b/tendrl/common/manager/manager.py
@@ -33,6 +33,7 @@ class Manager(object):
         self,
         name,
         integration_id,
+        node_id,
         config,
         events,
         persister_thread,
@@ -41,6 +42,7 @@ class Manager(object):
         self.name = name
         self._config = config
         self.integration_id = integration_id
+        self.node_id = node_id
         self._complete = gevent.event.Event()
         self._rpc_job_process_thread = RpcJobProcessThread(self)
         self._discovery_thread = events

--- a/tendrl/common/manager/rpc_job_process.py
+++ b/tendrl/common/manager/rpc_job_process.py
@@ -57,6 +57,12 @@ class EtcdRPC(object):
                     continue
                 raw_job = json.loads(job.value.decode('utf-8'))
                 try:
+                    # If current node's id does not fall under job's node_ids,
+                    # ignore the job and dont process
+                    if "node_ids" in raw_job:
+                        if self.syncJobThread._manager.node_id \
+                            not in raw_job['node_ids']:
+                            continue
                     raw_job, executed = self._process_job(
                         raw_job,
                         job.key,

--- a/tendrl/common/tests/test_manager.py
+++ b/tendrl/common/tests/test_manager.py
@@ -13,6 +13,7 @@ class MyManager(manager.Manager):
         self,
         name,
         integration_id,
+        node_id,
         config,
         events,
         persister_thread,
@@ -21,6 +22,7 @@ class MyManager(manager.Manager):
         super(MyManager, self).__init__(
             name,
             integration_id,
+            node_id,
             config,
             events,
             persister_thread,
@@ -36,6 +38,7 @@ class TestManager(object):
         self.manager = MyManager(
             "dummymodule",
             'aa22a6fe-87f0-45cf-8b70-2d0ff4c02af6',
+            'aa22a6fe-87f0-45cf-8b70-2d0ff4c02bf7',
             MagicMock(),
             MagicMock(),
             MagicMock(),


### PR DESCRIPTION
Now the job processor looks for a parameter with
name `node_ids` and if current node's id falls
under the same list, it would pick and process the
job. Only one of the nodes from the list would pick
the job for processing.

tendrl-bug-id: Tendrl/common#86
tendrl-spec: multiple_node_ids_in_jobs.adoc

Signed-off-by: Shubhendu <shtripat@redhat.com>